### PR TITLE
Replace swagger security from hard coded base security to user base security (superuser or staff user)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,6 @@ DEBUG=True
 DATABASE_URL=mysql+aiomysql://hoplin:hoplin@localhost:3306/fastapi_db
 REDIS_URL=redis://hoplin@localhost:6379/0
 
-# Application manager username and password
-SWAGGER_USERNAME=hoplin
-SWAGGER_PASSWORD=hoplin
-
 # Admin Page secret key
 ADMIN_SESSION_SECRET_KEY=admin_secret
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .idea
 .ipynb_checkpoints
 .mypy_cache

--- a/README.md
+++ b/README.md
@@ -33,13 +33,6 @@ Leveraged techniques described below
 - User List/Retrieve (Only superuser or staff)
   - `role_granted_user` defined in [`apps.core.auth.context`](apps/core/auth/context.py)
 
-## Admin Page
-
-This base code provide model admin page with [`SQLAdmin`](https://aminalaee.github.io/sqladmin/).
-**Admin page access requires a user account with superuser or staff privileges. Users without either of these cannot log in.**
-
-- Endpoint: `/admin`
-
 ![admin-pannel](img/admin-pannel.png)
 
 ## Create Superuser and commands
@@ -63,15 +56,19 @@ Execution Example
 
 Check out the [README.md](apps/commands/Readme.md) for more information on the pre-built commands in this application.
 
+## Admin Page
+
+This base code provide model admin page with [`SQLAdmin`](https://aminalaee.github.io/sqladmin/).
+**Admin page access requires a user account with superuser or staff privileges. Users without either of these cannot log in.**
+
+- Endpoint: `/admin`
+
 ## Swagger & Swagger Protection
 
-In this base code, Swagger is protected with Basic Authentication.
-The username and password for accessing Swagger are defined as environment variables:
+In this base code, Swagger is protected with authentication.
+**Swagger page access requires a user account with superuser or staff privileges. Users without either of these cannot log in.**
 
-- SWAGGER_USERNAME
-- SWAGGER_PASSWORD
-
-The Swagger UI is available at the endpoint: `/docs/swagger`
+- Endpoint: `/docs/swagger`
 
 ## Relevant documents on concepts leveraged in this base code
 

--- a/api.py
+++ b/api.py
@@ -28,7 +28,7 @@ app = FastAPI(
 
 # Global Dependency Injection
 root_container.wire(
-    packages=["apps.api", "apps.worker", "apps.core.auth"],
+    packages=["apps.api", "apps.worker", "apps.core.auth", "apps.application_docs"],
 )
 
 

--- a/apps/api/auth/exception.py
+++ b/apps/api/auth/exception.py
@@ -1,0 +1,10 @@
+from apps.core.exception.base import RootException
+from fastapi import status
+
+
+class PermissionDeniedException(RootException):
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            message="Permission Denied. You do not have permission to do this action.",
+        )

--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -24,14 +24,7 @@ class AdminPageAuthentication(AuthenticationBackend):
         if not username or not password:
             return False
 
-        user = await self.user_repository.retrieve_user_with_unique_clause(
-            key="username", value=username, filter_is_active=True
-        )
-
-        if not user:
-            user = await self.user_repository.retrieve_user_with_unique_clause(
-                key="email", value=username, filter_is_active=True
-            )
+        user = await self.user_repository.retrieve_superuser_or_staff(username=username)
 
         if not user:
             return False

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
     environment:
       - DATABASE_URL=mysql+aiomysql://hoplin:hoplin@mysql:3306/fastapi_db
       - REDIS_URL=redis://redis:6379/0
-      - SWAGGER_USERNAME=hoplin
-      - SWAGGER_PASSWORD=hoplin
       - ADMIN_SESSION_SECRET_KEY=admin_secret
       - JWT_ISSUER=Hoplin
       - JWT_SECRET_KEY=SECRET


### PR DESCRIPTION
## Pull Request

- Replace swagger security from hard coded base security to user base security (superuser or staff user)
- Remove `SWAGGER_USERNAME`, `SWAGGER_PASSWORD` key from  application `.env`. From now on, user requires to create superuser to perform this action.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update
- [ ] Test addition/modification
- [ ] Style changes
- [ ] Performance improvement


## Checklist

- [x] Run pre-commit linter
- [x] Test code all passed

## Additional Information
